### PR TITLE
replaced RemoveEventListener() by subscription.remove()

### DIFF
--- a/src/LoadingWireframe.js
+++ b/src/LoadingWireframe.js
@@ -30,7 +30,8 @@ class LoadingWireframe extends React.Component {
     super(props);
     this.state = {
       timingValue: new Animated.Value(0.0),
-      targets: {}
+      targets: {},
+      subscription: null
     };
 
     const dimensions = Dimensions.get('screen');
@@ -41,11 +42,12 @@ class LoadingWireframe extends React.Component {
     if (this.props.loading) {
       this._startFade();
     }
-    Dimensions.addEventListener('change', this._onDimensionChanged);
+    this.setState({subscription: Dimensions.addEventListener('change', this._onDimensionChanged)});
   }
 
   componentWillUnmount() {
-    Dimensions.removeEventListener('change', this._onDimensionChanged);
+    this.state.subscription.remove();
+    this.setState({subscription: null});
   }
 
   _onDimensionChanged = ({ screen }) => {
@@ -136,14 +138,14 @@ class LoadingWireframe extends React.Component {
 }
 
 const Wireframe = ({
-  opacity,
-  color,
-  loading,
-  children,
-  size,
-  onLayout,
-  ...restProps
-}) => {
+                     opacity,
+                     color,
+                     loading,
+                     children,
+                     size,
+                     onLayout,
+                     ...restProps
+                   }) => {
   if (!loading || !React.isValidElement(children)) {
     return children;
   }
@@ -151,9 +153,9 @@ const Wireframe = ({
   let wireframeStyle: ViewStyle = !children.props.style
     ? defaultStyles.wireframe
     : {
-        ...StyleSheet.flatten(children.props.style),
-        ...defaultStyles.wireframe
-      };
+      ...StyleSheet.flatten(children.props.style),
+      ...defaultStyles.wireframe
+    };
 
   const hasProvidedFixedSize =
     wireframeStyle.width !== null &&


### PR DESCRIPTION
fixed following warning:
> EventEmitter.removeListener('change', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.

in RN `0.68.2`

Note that all changes after line 50 are harmless indentation corrections made by my IDE prettier